### PR TITLE
Fix sudoku_specialized.rs not solving empty grids

### DIFF
--- a/optimized/sudoku_specialized.rs
+++ b/optimized/sudoku_specialized.rs
@@ -6,9 +6,9 @@
 use std::{
     fmt::{Display, Formatter},
     fs,
+    iter::FromIterator,
     ops::{Add, AddAssign, Sub, SubAssign},
     str::FromStr,
-    iter::FromIterator
 };
 
 #[derive(Clone, Eq, PartialEq)]
@@ -22,6 +22,7 @@ struct NumSet(u16);
 
 impl NumSet {
     const ALL: Self = Self(0b_111_111_111);
+    const NIL: Self = Self(0b_111_111_111_1);
     const EMPTY: Self = Self(0);
 
     fn one_hot(val: u8) -> Self {
@@ -176,8 +177,9 @@ impl Grid {
     }
 
     fn resolv(&mut self) -> bool {
-        let mut ibest = None;
-        let mut cbest = NumSet::ALL;
+        let mut ibest = 0;
+        let mut sbest = 0;
+        let mut cbest = NumSet::NIL;
         for (i, s) in self.spaces.iter().enumerate() {
             let c = self.free(s % 9, s / 9);
             if c.len() == 0 {
@@ -185,7 +187,8 @@ impl Grid {
                 return false;
             }
             if c.len() < cbest.len() {
-                ibest = Some((i, s));
+                ibest = i;
+                sbest = s;
                 cbest = c;
             }
             if c.len() == 1 {
@@ -194,20 +197,20 @@ impl Grid {
             }
         }
 
-        let Some((i, s)) = ibest else {
+        if cbest == NumSet::NIL {
             // solved
             return true;
         };
 
-        self.spaces.remove(i);
+        self.spaces.remove(ibest);
         for c in cbest {
-            self.data[s] = c;
+            self.data[sbest] = c;
             if self.resolv() {
                 return true;
             }
         }
-        self.data[s] = NumSet::EMPTY;
-        self.spaces.insert(s);
+        self.data[sbest] = NumSet::EMPTY;
+        self.spaces.insert(sbest);
 
         false
     }

--- a/optimized/sudoku_specialized.rs
+++ b/optimized/sudoku_specialized.rs
@@ -256,7 +256,8 @@ impl Display for Grid {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let content = fs::read_to_string("grids.txt")?;
-    let gg: Vec<&str> = content.lines().take(1956).collect();
+    let count = 1956;
+    let gg: Vec<&str> = content.lines().take(count).collect();
 
     let t = std::time::Instant::now();
     for line in gg {
@@ -264,6 +265,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         grid.resolv();
         println!("{} ", grid);
     }
-    println!("Took: {} s", (t.elapsed().as_millis() as f32) / 1000.0);
+    println!("Processed {count} boards");
+    println!("Took: {:.3}s", t.elapsed().as_secs_f64());
+    println!("{:?} per board", t.elapsed() / count as u32);
+    println!("{:.0} boards/sec", count as f64 / t.elapsed().as_secs_f64());
     Ok(())
 }


### PR DESCRIPTION
When the grid is solved -> `ibest` is never set, so the algorithm assumes that when `ibest` is not set -> the grid is solved.

`ibest` and `cbest` are set if the algorithm finds a tile with possibilities < than `cbest`. However, `cbest` starts at 9 possibilities, and it does not set if there are an == number of possibilities.

The only board where the tile with the fewest possibilities is 9, is the empty grid. All other grids have 8 possibilities etc. It's easier to just special-case this, but I found another optimization later somehow so it's still worth it.