### PR TITLE
Rust specialized bitset

### DIFF
--- a/sudoku_specialized.rs
+++ b/sudoku_specialized.rs
@@ -2,9 +2,9 @@
 //INFO: the simple algo, with specialized types (100grids)
 
 // from @raffimolero / redstoneboi https://www.reddit.com/r/rust/comments/183ex3i/comment/kaoxj74/?context=3
-
-use std::{fmt::Display, fs, ops::SubAssign, str::FromStr};
+#![feature(portable_simd)]
 use std::convert::TryFrom;
+use std::{fmt::Display, fs, ops::SubAssign, str::FromStr};
 
 struct NumSet([bool; 9]);
 
@@ -13,11 +13,12 @@ impl NumSet {
         Self([true; 9])
     }
 
-    fn iter<'a>(&'a self) -> impl 'a + Iterator<Item = u8> {
+    fn iter(&self) -> impl '_ + Iterator<Item = u8> {
         self.0
             .iter()
             .enumerate()
-            .filter_map(|(i, v)| v.then(|| i as u8))
+            .filter(|(_, &v)| v)
+            .map(|(i, _)| i as u8)
     }
 }
 
@@ -68,7 +69,7 @@ const EMPTY: u8 = 255;
 const ZERO_IDX: u8 = b'1';
 
 impl Grid {
-    fn sqr<'a>(&'a self, x: usize, y: usize) -> impl 'a + Iterator<Item = u8> {
+    fn sqr(&self, x: usize, y: usize) -> impl '_ + Iterator<Item = u8> {
         let x = (x / 3) * 3;
         let y = (y / 3) * 3;
         let i = y * 9 + x;
@@ -79,11 +80,11 @@ impl Grid {
             .copied()
     }
 
-    fn col<'a>(&'a self, x: usize) -> impl 'a + Iterator<Item = u8> {
+    fn col(&self, x: usize) -> impl '_ + Iterator<Item = u8> {
         (0..9).map(move |y| self.data[x + y * 9])
     }
 
-    fn row<'a>(&'a self, y: usize) -> impl 'a + Iterator<Item = u8> {
+    fn row(&self, y: usize) -> impl '_ + Iterator<Item = u8> {
         self.data[y * 9..y * 9 + 9].iter().copied()
     }
 


### PR DESCRIPTION
This PR increases the specialized Rust program's performance by a modest 1.5x:

```bash
November:sudoku_resolver sammysheep$ hyperfine -w 3 -r 30 ./sudoku_resolver ./sudoku_resolver2
Benchmark 1: ./sudoku_resolver
  Time (mean ± σ):     558.8 ms ±   2.0 ms    [User: 554.5 ms, System: 1.9 ms]
  Range (min … max):   555.8 ms … 565.4 ms    30 runs
 
Benchmark 2: ./sudoku_resolver2
  Time (mean ± σ):     347.1 ms ±   2.2 ms    [User: 343.4 ms, System: 1.5 ms]
  Range (min … max):   344.6 ms … 354.5 ms    30 runs
 
Summary
  ./sudoku_resolver2 ran
    1.61 ± 0.01 times faster than ./sudoku_resolver
```

Take-aways: 
- use a bitset instead of a boolean array
- tweak the encoding such that operations on the bitset are minimized